### PR TITLE
docs: fix contradictory license line and a typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ const depositInstructions = await pumpAmmSdk.depositInstructions(
 The SDK supports bi-directional swaps:
 
 ```typescript
-const swapSolanaState = await this.pumpAmmlSdk.swapSolanaState(poolKey, user);
+const swapSolanaState = await this.pumpAmmSdk.swapSolanaState(poolKey, user);
 
 const { globalConfig, pool, poolBaseAmount, poolQuoteAmount } = swapSolanaState;
 
@@ -160,7 +160,7 @@ const withdrawInstructions = await pumpAmmSdk.withdrawInstructions(
 
 ## License
 
-All rights reserved. See [LICENSE](LICENSE).
+Licensed under the MIT License. See [LICENSE](LICENSE).
 
 ## Links
 


### PR DESCRIPTION
Two small README corrections:

- **License section contradicted the actual license.** The README said "All rights reserved.", but the repo ships an MIT `LICENSE` and `package.json` declares `"license": "MIT"`. Changed the line to "Licensed under the MIT License." so the README matches the grant.
- **Typo in the Swap example:** `this.pumpAmmlSdk` → `this.pumpAmmSdk` (stray `l`).

Docs only; no code changes.
